### PR TITLE
Add more tests for clang transpiler

### DIFF
--- a/examples/cpp/31_oklt_v3_moving_avg/CMakeLists.txt
+++ b/examples/cpp/31_oklt_v3_moving_avg/CMakeLists.txt
@@ -2,9 +2,10 @@ compile_cpp_example_with_modes(oklt_v3_moving_avg main.cpp)
 
 add_custom_target(cpp_example_oklt_v3_moving_avg_cpy ALL 
 	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/constants.h constants.h
-	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/movingAverage.okl movingAverage.okl)
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/movingAverage.okl movingAverage.okl
+	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/vectorDot.okl vectorDot.okl)
 add_dependencies(examples_cpp_oklt_v3_moving_avg cpp_example_oklt_v3_moving_avg_cpy)
 target_sources(examples_cpp_oklt_v3_moving_avg 
-	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/movingAverage.okl
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/constants.h
-	)
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/movingAverage.okl
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/vectorDot.okl
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/constants.h)

--- a/examples/cpp/31_oklt_v3_moving_avg/vectorDot.okl
+++ b/examples/cpp/31_oklt_v3_moving_avg/vectorDot.okl
@@ -1,0 +1,28 @@
+#include "constants.h"
+
+@kernel void vectorDot(double *temp, const unsigned int n, const double *a,
+    const double *b) {
+  for (unsigned int i = 0; i < (n + THREADS_PER_BLOCK - 1) / THREADS_PER_BLOCK; i++; @outer) {
+    @shared float s[THREADS_PER_BLOCK];
+
+    for (int j = 0; j < THREADS_PER_BLOCK; j++; @inner) {
+      int t = i * THREADS_PER_BLOCK + j;
+      if (t < n)
+        s[j] = a[t] * b[t];
+      else
+        s[j] = 0.0;
+    }
+
+    for (int k = (THREADS_PER_BLOCK + 1) / 2; k > 0; k /= 2) {
+      for (int j = 0; j < THREADS_PER_BLOCK; j++; @inner) {
+        if (j < k)
+          s[j] += s[j + k];
+      }
+    }
+
+    for (int j = 0; j < THREADS_PER_BLOCK; j++; @inner) {
+      if (j == 0)
+        temp[i] = s[0];
+    }
+  }
+}


### PR DESCRIPTION
## Description

I get the following error when the `vectorDot()` kernel is run.

```sh
terminate called after throwing an instance of 'occa::exception'
  what():  
---[ Error ]--------------------------------------------------------------------
    File     : /lustre/orion/fus166/scratch/thilina/Workspace/anl/occa-transpiler/occa/src/dtype/dtype.cpp
    Line     : 528
    Function : fromJson
    Message  : Unknown dtype builtin [unsigned int]
    Stack
      15 occa::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
      14 occa::dtype_t::fromJson(occa::json const&)
      13 occa::lang::argMetadata_t::fromJson(occa::json const&)
      12 occa::lang::kernelMetadata_t::fromJson(occa::json const&)
      11 occa::transpiler::makeMetadata(occa::lang::sourceMetadata_t&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
      10 /lustre/orion/fus166/scratch/thilina/Workspace/anl/occa-transpiler/occa/build/lib/libocca.so(+0x2de573)
       9 occa::transpiler::Transpiler::run(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, occa::json const&)
       8 occa::serial::v3::transpileFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, occa::json const&, occa::lang::sourceMetadata_t&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
       7 occa::serial::device::buildKernel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, occa::hash_t, occa::json const&, bool)
       6 occa::serial::device::buildKernel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, occa::hash_t, occa::json const&)
       5 occa::device::buildKernel(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, occa::json const&) const
       4 ./examples_cpp_oklt_v3_moving_avg()
       3 ./examples_cpp_oklt_v3_moving_avg()
       2 /lib64/libc.so.6(__libc_start_main+0xef)
       1 ./examples_cpp_oklt_v3_moving_avg()
================================================================================
```

I think OCCA supports `unsigned int` (I may be wrong). I am assuming this is a
transpiler issue since the error is from the transpiler).
